### PR TITLE
Execution Status Enum

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,3 +11,4 @@ chrono = { version ="0.4.23", features = ["serde", "rustc-serialize"] }
 reqwest = { version = "0.11.13", features = ["json"] }
 serde = { version = "1.0.151", features=["derive"] }
 tokio = { version = "1.23.0", features = ["full"] }
+serde_with = "2.1.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -119,6 +119,7 @@ impl DuneClient {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::response::ExecutionStatus;
     use dotenv::dotenv;
     use serde::Deserialize;
     use std::env;
@@ -183,7 +184,7 @@ mod tests {
     async fn get_status() {
         let dune = get_dune();
         let status = dune.get_status(JOB_ID).await.unwrap();
-        assert_eq!(status.state, "QUERY_STATE_COMPLETED")
+        assert_eq!(status.state, ExecutionStatus::Complete)
     }
 
     #[tokio::test]


### PR DESCRIPTION
Closes #2

We implement Deserialization (via impl FromStr) for an Enum representation of Query `ExecutionStatus`. All relevant tests are provided.