### PR TITLE
Query Parameters

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,3 +12,4 @@ reqwest = { version = "0.11.13", features = ["json"] }
 serde = { version = "1.0.151", features=["derive"] }
 tokio = { version = "1.23.0", features = ["full"] }
 serde_with = "2.1.0"
+serde_json = "1.0.91"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,9 @@
 
 extern crate core;
 
+pub mod parameters;
 mod response;
+mod util;
 
 use crate::response::{
     CancellationResponse, DuneError, ExecutionResponse, GetResultResponse, GetStatusResponse,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,11 +6,14 @@ pub mod parameters;
 mod response;
 mod util;
 
+use crate::parameters::Parameter;
 use crate::response::{
     CancellationResponse, DuneError, ExecutionResponse, GetResultResponse, GetStatusResponse,
 };
 use reqwest::{Error, Response};
 use serde::de::DeserializeOwned;
+use serde_json::json;
+use std::collections::HashMap;
 
 const BASE_URL: &str = "https://api.dune.com/api/v1";
 
@@ -43,19 +46,24 @@ impl From<Error> for DuneRequestError {
 }
 
 impl DuneClient {
-    async fn _post(&self, route: &str) -> Result<Response, Error> {
+    async fn _post(&self, route: &str, params: Option<Vec<Parameter>>) -> Result<Response, Error> {
+        let params = params
+            .unwrap_or_default()
+            .into_iter()
+            .map(|p| (p.key, p.value))
+            .collect::<HashMap<_, _>>();
         let request_url = format!("{BASE_URL}/{route}");
         let client = reqwest::Client::new();
         client
             .post(&request_url)
             .header("x-dune-api-key", &self.api_key)
+            .json(&json!({ "query_parameters": params }))
             .send()
             .await
     }
 
     async fn _get(&self, job_id: &str, command: &str) -> Result<Response, Error> {
         let request_url = format!("{BASE_URL}/execution/{job_id}/{command}");
-        println!("{}", request_url);
         let client = reqwest::Client::new();
         client
             .get(&request_url)
@@ -77,9 +85,13 @@ impl DuneClient {
             Err(DuneRequestError::from(err))
         }
     }
-    async fn execute_query(&self, query_id: u32) -> Result<ExecutionResponse, DuneRequestError> {
+    async fn execute_query(
+        &self,
+        query_id: u32,
+        params: Option<Vec<Parameter>>,
+    ) -> Result<ExecutionResponse, DuneRequestError> {
         let response = self
-            ._post(&format!("query/{query_id}/execute"))
+            ._post(&format!("query/{query_id}/execute"), params)
             .await
             .map_err(DuneRequestError::from)?;
         DuneClient::_parse_response::<ExecutionResponse>(response).await
@@ -90,7 +102,7 @@ impl DuneClient {
         job_id: &str,
     ) -> Result<CancellationResponse, DuneRequestError> {
         let response = self
-            ._post(&format!("execution/{job_id}/cancel"))
+            ._post(&format!("execution/{job_id}/cancel"), None)
             .await
             .map_err(DuneRequestError::from)?;
         DuneClient::_parse_response::<CancellationResponse>(response).await
@@ -120,6 +132,7 @@ impl DuneClient {
 mod tests {
     use super::*;
     use crate::response::ExecutionStatus;
+    use crate::util::date_parse;
     use dotenv::dotenv;
     use serde::Deserialize;
     use std::env;
@@ -139,7 +152,7 @@ mod tests {
         let dune = DuneClient {
             api_key: "Baloney".parse().unwrap(),
         };
-        let error = dune.execute_query(QUERY_ID).await.unwrap_err();
+        let error = dune.execute_query(QUERY_ID, None).await.unwrap_err();
         assert_eq!(
             error,
             DuneRequestError::Dune(String::from("invalid API Key"))
@@ -149,7 +162,7 @@ mod tests {
     #[tokio::test]
     async fn invalid_query_id() {
         let dune = get_dune();
-        let error = dune.execute_query(u32::MAX).await.unwrap_err();
+        let error = dune.execute_query(u32::MAX, None).await.unwrap_err();
         assert_eq!(
             error,
             DuneRequestError::Dune(String::from("Query not found"))
@@ -174,10 +187,23 @@ mod tests {
     #[tokio::test]
     async fn execute_query() {
         let dune = get_dune();
-        let exec = dune.execute_query(QUERY_ID).await.unwrap();
+        let exec = dune.execute_query(QUERY_ID, None).await.unwrap();
         // Also testing cancellation!
         let cancellation = dune.cancel_execution(&exec.execution_id).await.unwrap();
         assert!(cancellation.success);
+    }
+
+    #[tokio::test]
+    async fn execute_query_with_params() {
+        let dune = get_dune();
+        let all_parameter_types = vec![
+            Parameter::date("DateField", date_parse("2022-05-04T00:00:00.0Z").unwrap()),
+            Parameter::number("NumberField", "3.1415926535"),
+            Parameter::text("TextField", "Plain Text"),
+            Parameter::list("ListField", "Option 1"),
+        ];
+        let exec_result = dune.execute_query(1215383, Some(all_parameter_types)).await;
+        assert!(exec_result.is_ok())
     }
 
     #[tokio::test]

--- a/src/parameters.rs
+++ b/src/parameters.rs
@@ -1,0 +1,98 @@
+use chrono::NaiveDateTime;
+use serde::Serialize;
+
+#[derive(Serialize, Debug, PartialEq)]
+pub enum ParameterType {
+    Text,
+    Number,
+    Enum,
+    Date,
+}
+
+#[derive(Serialize, Debug, PartialEq)]
+pub struct Parameter {
+    key: String,
+    ptype: ParameterType,
+    value: String,
+}
+
+impl Parameter {
+    fn date(name: &str, value: NaiveDateTime) -> Self {
+        Parameter {
+            key: String::from(name),
+            ptype: ParameterType::Date,
+            // Dune date precision is to the minute.
+            // YYYY-MM-DD HH:MM
+            value: value.to_string()[..16].parse().unwrap(),
+        }
+    }
+
+    fn text(name: &str, value: &str) -> Self {
+        Parameter {
+            key: String::from(name),
+            ptype: ParameterType::Text,
+            value: String::from(value),
+        }
+    }
+
+    fn number(name: &str, value: &str) -> Self {
+        Parameter {
+            key: String::from(name),
+            ptype: ParameterType::Number,
+            value: String::from(value),
+        }
+    }
+
+    fn list(name: &str, value: &str) -> Self {
+        Parameter {
+            key: String::from(name),
+            ptype: ParameterType::Enum,
+            value: String::from(value),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::util::date_parse;
+
+    #[test]
+    fn new_parameter() {
+        assert_eq!(
+            Parameter::text("MyText", "Hello!"),
+            Parameter {
+                key: "MyText".to_string(),
+                ptype: ParameterType::Text,
+                value: "Hello!".to_string(),
+            }
+        );
+        assert_eq!(
+            Parameter::list("MyEnum", "Item 1"),
+            Parameter {
+                key: "MyEnum".to_string(),
+                ptype: ParameterType::Enum,
+                value: "Item 1".to_string(),
+            }
+        );
+        assert_eq!(
+            Parameter::number("MyNumber", "3.14159"),
+            Parameter {
+                key: "MyNumber".to_string(),
+                ptype: ParameterType::Number,
+                value: "3.14159".to_string(),
+            }
+        );
+        let date_str = "2022-01-01T01:02:03.123Z";
+        assert_eq!(
+            Parameter::date("MyDate", date_parse(date_str).unwrap()),
+            Parameter {
+                key: "MyDate".to_string(),
+                ptype: ParameterType::Date,
+                value: "2022-01-01 01:02".to_string(),
+            }
+        )
+    }
+    #[test]
+    fn terminal_statuses() {}
+}

--- a/src/parameters.rs
+++ b/src/parameters.rs
@@ -11,23 +11,25 @@ pub enum ParameterType {
 
 #[derive(Serialize, Debug, PartialEq)]
 pub struct Parameter {
-    key: String,
+    pub key: String,
+    // #[serde(rename(serialize = "type"))]
+    #[serde(skip_serializing)]
     ptype: ParameterType,
-    value: String,
+    pub value: String,
 }
 
 impl Parameter {
-    fn date(name: &str, value: NaiveDateTime) -> Self {
+    pub fn date(name: &str, value: NaiveDateTime) -> Self {
         Parameter {
             key: String::from(name),
             ptype: ParameterType::Date,
-            // Dune date precision is to the minute.
-            // YYYY-MM-DD HH:MM
-            value: value.to_string()[..16].parse().unwrap(),
+            // Dune date precision is to the second.
+            // YYYY-MM-DD HH:MM:SS
+            value: value.to_string()[..19].parse().unwrap(),
         }
     }
 
-    fn text(name: &str, value: &str) -> Self {
+    pub fn text(name: &str, value: &str) -> Self {
         Parameter {
             key: String::from(name),
             ptype: ParameterType::Text,
@@ -35,7 +37,7 @@ impl Parameter {
         }
     }
 
-    fn number(name: &str, value: &str) -> Self {
+    pub fn number(name: &str, value: &str) -> Self {
         Parameter {
             key: String::from(name),
             ptype: ParameterType::Number,
@@ -43,12 +45,16 @@ impl Parameter {
         }
     }
 
-    fn list(name: &str, value: &str) -> Self {
+    pub fn list(name: &str, value: &str) -> Self {
         Parameter {
             key: String::from(name),
             ptype: ParameterType::Enum,
             value: String::from(value),
         }
+    }
+
+    pub fn to_dune(&self) -> String {
+        serde_json::to_string(self).unwrap()
     }
 }
 
@@ -89,10 +95,8 @@ mod tests {
             Parameter {
                 key: "MyDate".to_string(),
                 ptype: ParameterType::Date,
-                value: "2022-01-01 01:02".to_string(),
+                value: "2022-01-01 01:02:03".to_string(),
             }
         )
     }
-    #[test]
-    fn terminal_statuses() {}
 }

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,0 +1,22 @@
+use chrono::{NaiveDateTime, ParseError};
+
+pub fn date_parse(date_str: &str) -> Result<NaiveDateTime, ParseError> {
+    // Supported formats:
+    // "%Y-%m-%d" or "%Y-%m-%dT%H:%M:%S.%fZ"
+    NaiveDateTime::parse_from_str(&date_str, "%Y-%m-%dT%H:%M:%S.%fZ")
+    // Ok(DateTime::<Utc>::from_utc(native?, Utc))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn new_parameter() {
+        let date_str = "2022-01-01T01:02:03.123Z";
+        assert_eq!(
+            date_parse(date_str).unwrap().to_string(),
+            "2022-01-01 01:02:03.000000123"
+        )
+    }
+}

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,10 +1,8 @@
 use chrono::{NaiveDateTime, ParseError};
 
 pub fn date_parse(date_str: &str) -> Result<NaiveDateTime, ParseError> {
-    // Supported formats:
-    // "%Y-%m-%d" or "%Y-%m-%dT%H:%M:%S.%fZ"
-    NaiveDateTime::parse_from_str(&date_str, "%Y-%m-%dT%H:%M:%S.%fZ")
-    // Ok(DateTime::<Utc>::from_utc(native?, Utc))
+    // "%Y-%m-%dT%H:%M:%S.%fZ"
+    NaiveDateTime::parse_from_str(date_str, "%Y-%m-%dT%H:%M:%S.%fZ")
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Closes #3 
Execute Query Accepts query parameters in the form:

```
curl -X POST \
    -d '{"query_parameters": { "param1":24}}'  \
    -H x-dune-api-key:{{api_key}}  \
    "https://api.dune.com/api/v1/query/{{query_id}}/execute"
```

as specified in the docs [here](https://dune.com/docs/api/api-reference/execute-query-id/#returns)

This PR introduces Parameters struct and adds them to the Post query for `execute_query` client route (optionally).

