### PR TITLE
Better Coverage

### DIFF
--- a/src/parameters.rs
+++ b/src/parameters.rs
@@ -1,24 +1,33 @@
 use chrono::NaiveDateTime;
-use serde::Serialize;
 
-#[derive(Serialize, Debug, PartialEq)]
-pub enum ParameterType {
+/// Dune supports 4 different parameter types enumerated here:
+/// In end, all parameters are passed to
+/// Dune via the API as JSON strings.
+#[derive(Debug, PartialEq)]
+enum ParameterType {
+    /// A.k.a. string (used for transaction hashes and evm addresses, etc.)
     Text,
+    /// Encapsulates all numerical types (integer and float).
     Number,
+    /// A.k.a List or Dropdown of text.
     Enum,
+    /// Dune Date strings take the form `YYYY-MM-DD hh:mm:ss`
     Date,
 }
 
-#[derive(Serialize, Debug, PartialEq)]
+#[derive(Debug, PartialEq)]
 pub struct Parameter {
+    /// Parameter Name.
     pub key: String,
-    // #[serde(rename(serialize = "type"))]
-    #[serde(skip_serializing)]
+    /// Currently unused type field
+    /// (will become relevant when API supports `upsert_query`)
     ptype: ParameterType,
+    /// String representation of parameter's value
     pub value: String,
 }
 
 impl Parameter {
+    /// Constructor of Date type Parameter
     pub fn date(name: &str, value: NaiveDateTime) -> Self {
         Parameter {
             key: String::from(name),
@@ -29,6 +38,7 @@ impl Parameter {
         }
     }
 
+    /// Constructor of Text type Parameter
     pub fn text(name: &str, value: &str) -> Self {
         Parameter {
             key: String::from(name),
@@ -37,6 +47,7 @@ impl Parameter {
         }
     }
 
+    /// Constructor of Numeric type Parameter
     pub fn number(name: &str, value: &str) -> Self {
         Parameter {
             key: String::from(name),
@@ -45,16 +56,13 @@ impl Parameter {
         }
     }
 
+    /// Constructor of List/Enum type Parameter
     pub fn list(name: &str, value: &str) -> Self {
         Parameter {
             key: String::from(name),
             ptype: ParameterType::Enum,
             value: String::from(value),
         }
-    }
-
-    pub fn to_dune(&self) -> String {
-        serde_json::to_string(self).unwrap()
     }
 }
 
@@ -98,5 +106,14 @@ mod tests {
                 value: "2022-01-01 01:02:03".to_string(),
             }
         )
+    }
+
+    #[test]
+    fn derived_debug() {
+        assert_eq!(format!("{:?}", ParameterType::Date), "Date");
+        assert_eq!(
+            format!("{:?}", Parameter::number("MyNumber", "3.14159")),
+            "Parameter { key: \"MyNumber\", ptype: Number, value: \"3.14159\" }"
+        );
     }
 }

--- a/src/response.rs
+++ b/src/response.rs
@@ -190,6 +190,7 @@ mod tests {
             Ok(ExecutionStatus::Failed)
         );
     }
+
     #[test]
     fn terminal_statuses() {
         assert!(ExecutionStatus::Complete.is_terminal());
@@ -198,5 +199,128 @@ mod tests {
 
         assert!(!ExecutionStatus::Pending.is_terminal());
         assert!(!ExecutionStatus::Executing.is_terminal());
+    }
+    #[test]
+    fn derive_debug() {
+        assert_eq!(
+            format!(
+                "{:?}",
+                DuneError {
+                    error: "broken".to_string()
+                }
+            ),
+            "DuneError { error: \"broken\" }"
+        );
+        assert_eq!(
+            format!(
+                "{:?}",
+                ExecutionResponse {
+                    execution_id: "jerb".to_string(),
+                    state: ExecutionStatus::Failed
+                }
+            ),
+            "ExecutionResponse { execution_id: \"jerb\", state: Failed }"
+        );
+        assert_eq!(
+            format!("{:?}", CancellationResponse { success: false }),
+            "CancellationResponse { success: false }"
+        );
+        let query_id = 71;
+        let execution_id = "jerb ID";
+
+        assert_eq!(
+            format!(
+                "{:?}",
+                GetStatusResponse {
+                    execution_id: execution_id.to_string(),
+                    query_id,
+                    state: ExecutionStatus::Pending,
+                    times: ExecutionTimes {
+                        submitted_at: Default::default(),
+                        expires_at: Default::default(),
+                        execution_started_at: Default::default(),
+                        execution_ended_at: Default::default(),
+                    },
+                    queue_position: Some(10),
+                    result_metadata: Some(ResultMetaData {
+                        column_names: vec![],
+                        result_set_bytes: 0,
+                        total_row_count: 0,
+                        datapoint_count: 0,
+                        pending_time_millis: None,
+                        execution_time_millis: 0,
+                    }),
+                }
+            ),
+            "GetStatusResponse { \
+                execution_id: \"jerb ID\", \
+                query_id: 71, \
+                state: Pending, \
+                times: ExecutionTimes { \
+                    submitted_at: 1970-01-01T00:00:00Z, \
+                    expires_at: 1970-01-01T00:00:00Z, \
+                    execution_started_at: 1970-01-01T00:00:00Z, \
+                    execution_ended_at: 1970-01-01T00:00:00Z \
+                }, \
+                queue_position: Some(10), \
+                result_metadata: Some(ResultMetaData { \
+                        column_names: [], \
+                        result_set_bytes: 0, \
+                        total_row_count: 0, \
+                        datapoint_count: 0, \
+                        pending_time_millis: None, \
+                        execution_time_millis: 0 \
+                }\
+             ) }",
+        );
+        assert_eq!(
+            format!(
+                "{:?}",
+                GetResultResponse {
+                    execution_id: execution_id.to_string(),
+                    query_id,
+                    state: ExecutionStatus::Complete,
+                    times: ExecutionTimes {
+                        submitted_at: Default::default(),
+                        expires_at: Default::default(),
+                        execution_started_at: Default::default(),
+                        execution_ended_at: Default::default(),
+                    },
+                    result: ExecutionResult::<u8> {
+                        rows: vec![],
+                        metadata: ResultMetaData {
+                            column_names: vec![],
+                            result_set_bytes: 0,
+                            total_row_count: 0,
+                            datapoint_count: 0,
+                            pending_time_millis: None,
+                            execution_time_millis: 0,
+                        }
+                    },
+                }
+            ),
+            "GetResultResponse { \
+                execution_id: \"jerb ID\", \
+                query_id: 71, \
+                state: Complete, \
+                times: ExecutionTimes { \
+                    submitted_at: 1970-01-01T00:00:00Z, \
+                    expires_at: 1970-01-01T00:00:00Z, \
+                    execution_started_at: 1970-01-01T00:00:00Z, \
+                    execution_ended_at: 1970-01-01T00:00:00Z \
+                }, \
+                result: ExecutionResult { \
+                    rows: [], \
+                    metadata: ResultMetaData { \
+                        column_names: [], \
+                        result_set_bytes: 0, \
+                        total_row_count: 0, \
+                        datapoint_count: 0, \
+                        pending_time_millis: None, \
+                        execution_time_millis: 0 \
+                    } \
+                } \
+            }",
+        );
     }
 }


### PR DESCRIPTION
Mostly testing all derived functionality of Response types. Bringing coverage from ~47 to over 90.

The only thing we can't easily test now is request errors resulting from API calls (since there are no scenarios where a user could really make one).